### PR TITLE
Updated jdbc driver url,connection url

### DIFF
--- a/SpringBootWithMySqlCrud/src/main/resources/application.properties
+++ b/SpringBootWithMySqlCrud/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 
 # Spring DATASOURCE (DataSourceAutoConfiguration & DataSourceProperties)
-spring.datasource.driver-class-name=com.mysql.jdbc.Driver
-spring.datasource.url = jdbc:mysql://localhost:3306/spirngbootwithmysql?useSSL=false
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.datasource.url = jdbc:mysql://localhost:3306/spirngbootwithmysql?allowPublicKeyRetrieval=true&useSSL=false&serverTimezone=UTC
 spring.datasource.username = root
 spring.datasource.password = root
 


### PR DESCRIPTION
JDBC Driver url specification has changed as per latest mysql.Although old one doesn't cause any harm,but gives us warnings.
Also changed JDBC Connection URL as per latest requirements so as they don't throw any warnings.